### PR TITLE
Fix UI config resolution in pass-docker

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - back
 
   proxy:
-    image: oapass/httpd-proxy:20200507@sha256:e8ad2e759fe270998efc80bdcacbeb3f965b4b83d875478e36b0ce4c104bb2d3
+    image: oapass/httpd-proxy:20220426@sha256:3caf4ebebc432bc9eee29110091a3bed41a71a5094257a820befa40786992e7b
     container_name: proxy
     networks:
       - front

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -29,6 +29,13 @@ module.exports = function (defaults) {
 
         return className;
       },
+    },
+    fingerprint: {
+      exclude: [
+        'branding.css',
+        'error-icon.png',
+        'fullSizeLogo.png'
+      ]
     }
   });
 


### PR DESCRIPTION
* Update proxy image
* Don't fingerprint some assets

### Testing
You can sort of verify locally by bringing up the `ember` image in the dev docker environment and running `yarn build` to build the production artifact. In the `dist/` directory, `branding.css`, `error-iron.png`, and `fullSizeLogo.png` should NOT be fingerprinted